### PR TITLE
Add Light Mode and Settings for Color Scheme

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,53 @@
+function applyMode(mode) {
+  const root = document.documentElement;
+  root.classList.remove('extension-light-mode', 'extension-dark-mode');
+  if (mode === 'light') {
+    root.classList.add('extension-light-mode');
+  } else if (mode === 'dark') {
+    root.classList.add('extension-dark-mode');
+  }
+  // else: 'system' = no class, rely on prefers-color-scheme
+}
+
+let currentMode = "system";
+let mql = null;
+
+function updateForSystemPref() {
+  if (currentMode === "system") {
+    // Remove explicit classes, let CSS handle
+    applyMode("system");
+  }
+}
+
+function listenSystemChange(enable) {
+  if (enable) {
+    if (!mql) {
+      mql = window.matchMedia("(prefers-color-scheme: dark)");
+      mql.addEventListener("change", updateForSystemPref);
+    }
+  } else if (mql) {
+    mql.removeEventListener("change", updateForSystemPref);
+    mql = null;
+  }
+}
+
+function setModeFromStorage() {
+  chrome.storage.sync.get({ colorMode: "system" }, (data) => {
+    const mode = data.colorMode || "system";
+    currentMode = mode;
+    applyMode(mode);
+    listenSystemChange(mode === "system");
+  });
+}
+
+// Initial load
+setModeFromStorage();
+
+// Listen for changes from options page
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && changes.colorMode) {
+    currentMode = changes.colorMode.newValue || "system";
+    applyMode(currentMode);
+    listenSystemChange(currentMode === "system");
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,21 @@
 {
   "manifest_version": 3,
   "name": "Bitgrip Presentation Styles",
-  "version": "1.0",
+  "version": "1.1",
   "description": "Applies Bitgrip corporate identity styles to browser based presentations",
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "storage"
   ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "content_scripts": [
     {
       "matches": ["https://bitgrip.atlassian.net/wiki/*"],
-      "css": ["styles.css"]
+      "css": ["styles.css"],
+      "js": ["contentScript.js"]
     }
   ],
   "icons": {

--- a/options.html
+++ b/options.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bitgrip Presentation Styles – Settings</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      max-width: 400px;
+      margin: 2rem auto;
+      background: #fafbfc;
+      color: #222;
+      padding: 2rem;
+      border-radius: 10px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    }
+    fieldset {
+      border: 1px solid #bbb;
+      border-radius: 6px;
+      padding: 1rem;
+    }
+    legend {
+      font-weight: bold;
+    }
+    label {
+      display: block;
+      margin: 0.5em 0 0.5em 1.4em;
+      cursor: pointer;
+    }
+    input[type="radio"] {
+      margin-right: 0.7em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Bitgrip Presentation Styles – Settings</h1>
+  <form>
+    <fieldset>
+      <legend>Color mode</legend>
+      <label>
+        <input type="radio" name="colorMode" value="system" checked>
+        System default
+      </label>
+      <label>
+        <input type="radio" name="colorMode" value="light">
+        Light mode
+      </label>
+      <label>
+        <input type="radio" name="colorMode" value="dark">
+        Dark mode
+      </label>
+    </fieldset>
+  </form>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const radios = Array.from(document.querySelectorAll('input[name="colorMode"]'));
+
+  // Load saved preference
+  chrome.storage.sync.get({ colorMode: "system" }, (data) => {
+    const mode = data.colorMode || "system";
+    const found = radios.find(r => r.value === mode);
+    if (found) found.checked = true;
+  });
+
+  // Save on change
+  radios.forEach(radio => {
+    radio.addEventListener('change', function() {
+      if (this.checked) {
+        chrome.storage.sync.set({ colorMode: this.value });
+      }
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,33 @@
+/* ---------- Color scheme variables ---------- */
+:root {
+  --ds-text: #000;
+  --ds-surface: #fff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ds-text: #fff;
+    --ds-surface: #000;
+  }
+}
+
+/* Explicit extension override: dark */
+html.extension-dark-mode {
+  color-scheme: dark;
+  --ds-text: #fff;
+  --ds-surface: #000;
+}
+
+/* Explicit extension override: light */
+html.extension-light-mode {
+  color-scheme: light;
+  --ds-text: #000;
+  --ds-surface: #fff;
+}
+
 /* Bitgrip presentation styles for Confluence */
 
-/* Dark mode styles */
+/* Dark mode styles for Confluence's own dark mode */
 html[data-color-mode=dark][data-theme~=dark\:dark] {
   color-scheme: dark;
   --ds-text: #fff;
@@ -14,6 +41,7 @@ html[data-color-mode=dark][data-theme~=dark\:dark] {
   background-position: left 2rem top 1.3rem;
   background-size: auto;
   background-attachment: fixed;
+  background-color: var(--ds-surface);
 }
 
 /* Typography styles */
@@ -23,6 +51,7 @@ body #presenter-mode-container,
 #presenter-mode-title-text ul,
 #presenter-mode-title-text ol {
   font-family: "PP Right Grotesk Text", sans-serif !important;
+  color: var(--ds-text);
 }
 
 #presenter-mode-container h1,
@@ -32,28 +61,35 @@ body #presenter-mode-container,
 #presenter-mode-container h5,
 #presenter-mode-container h6 {
   font-family: "PPRightGrotesk-WideBold", "PPrg-wide", sans-serif !important;
+  color: var(--ds-text);
 }
 
 /* Title text styles */
 #presenter-mode-title-text h1 {
-  color: white !important;
+  color: #fff !important;
+}
+html.extension-light-mode #presenter-mode-title-text h1 {
+  color: var(--ds-text) !important;
 }
 
 /* Horizontal rule styling */
 #presenter-mode-container hr {
   margin: 10rem 0;
+  border-color: var(--ds-text);
 }
 
 /* Example styling for presentation mode */
 .confluence-presentation-mode {
-    /* Add your custom presentation styles here */
-    background-color: #ffffff;
+    background-color: var(--ds-surface);
     font-family: 'Arial', sans-serif;
+    color: var(--ds-text);
 }
 
 /* Presentation header styling */
 .presentation-header {
     padding: 20px;
+    background: var(--ds-surface);
+    color: var(--ds-text);
 }
 
 /* Presentation content styling */
@@ -61,6 +97,8 @@ body #presenter-mode-container,
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
+    background: var(--ds-surface);
+    color: var(--ds-text);
 }
 
 /* Add more specific styles as needed */


### PR DESCRIPTION
This pull request introduces styles for a light mode along with a settings interface to toggle between light and dark modes. Key changes include:

1. **Color Scheme Handling**: A new JavaScript file (`contentScript.js`) has been added to handle the application of color modes based on user preferences or system settings.

2. **User Settings Interface**: An options page (`options.html`) has been created that provides radio buttons for users to select their preferred color mode (System default, Light mode, Dark mode). The selection is saved using Chrome's storage API.

3. **CSS Updates**: The main stylesheet (`styles.css`) was updated to include corresponding CSS variables for light and dark themes, allowing for easier customization based on the selected mode.

4. **Manifest Update**: The `manifest.json` was modified to include the options page and required permissions.

This enhancement ensures a more flexible and user-friendly experience by allowing users to choose a visual style that suits their preference.

---

> This pull request was co-created with Cosine Genie

Original Task: [bitgrip-presentation-styles/nyufzjb3w2jn](https://cosine.sh/bitgrip/bitgrip-presentation-styles/task/nyufzjb3w2jn)
Author: Jan-Henrik Hempel
